### PR TITLE
Validate coordinates before opening Google Maps

### DIFF
--- a/gmaps_helper.js
+++ b/gmaps_helper.js
@@ -27,6 +27,8 @@
     if(!name){
       var strong = btn.closest("li, .spot, .item, .card"); if(strong){ var t = strong.querySelector("strong"); if(t) name = t.textContent.trim(); }
     }
-    if(lat && lon){ e.preventDefault(); openGoogleMapsApp(name||"", lat, lon); }
+    lat = parseFloat(lat); lon = parseFloat(lon);
+    if(!isFinite(lat) || !isFinite(lon)) return;
+    e.preventDefault(); openGoogleMapsApp(name||"", lat, lon);
   }, false);
 })();


### PR DESCRIPTION
## Summary
- Parse latitude and longitude as floats and verify they are finite before launching Google Maps.

## Testing
- `npm test` (fails: missing package.json)
- `node --check gmaps_helper.js`


------
https://chatgpt.com/codex/tasks/task_e_6898288adc448320bbe9226cf5128ad3