### PR TITLE
Clarify meals-loading-helper comment

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,7 @@
 修正パッチ（フルJS差し替え）
 - 直前のZIPに短縮版JSが入ってしまい検索が動かなくなっていました。
 - `meals.js` と `spots.js` をフル実装に差し替え。これで検索が復活します。
+- `meals-loading-helper.js` — show '検索中…' while fetching
 
 適用:
 1) ZIPを展開し、`meals.js` / `spots.js` を `/test` 直下に上書き

--- a/meals-loading-helper.js
+++ b/meals-loading-helper.js
@@ -1,4 +1,4 @@
-// meals.js — show "検索中…" while fetching
+// meals-loading-helper.js — show '検索中…' while fetching
 (function(){
   // We assume existing functions are defined as in your current meals.js
   const origRun = window.__MEALS_RUN__;


### PR DESCRIPTION
## Summary
- fix meals-loading-helper comment to reference file name and show '検索中…'
- document meals-loading-helper helper in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898289a93c88320882d0298ae71cf8f