### PR TITLE
Add home button icons and adjust header spacing

### DIFF
--- a/favorites.html
+++ b/favorites.html
@@ -17,7 +17,7 @@
 <body>
 <header class="top">
   <div class="title">お気に入り</div>
-  <button id="addToHome" class="primary">ホームに追加</button>
+  <button id="addToHome" class="primary"><span class="icon">+</span> ホームに追加</button>
 </header>
 
 <main>

--- a/index.html
+++ b/index.html
@@ -11,9 +11,7 @@
 <body>
 <header class="top">
   <div class="title">天気・WBGT</div>
-  <div class="row">
-    <button id="addToHome" class="primary">ホームに追加</button>
-  </div>
+  <button id="addToHome" class="primary"><span class="icon">+</span> ホームに追加</button>
 </header>
 
 <main>

--- a/meals.html
+++ b/meals.html
@@ -10,9 +10,7 @@
 <body>
 <header class="top">
   <div class="title">たべる（妊娠配慮）</div>
-  <div class="row">
-    <button id="addToHome" class="primary">ホームに追加</button>
-  </div>
+  <button id="addToHome" class="primary"><span class="icon">+</span> ホームに追加</button>
 </header>
 
 <main>

--- a/spots.html
+++ b/spots.html
@@ -10,7 +10,7 @@
 <body>
 <header class="top">
   <div class="title">スポット検索</div>
-  <button id="addToHome" class="primary">ホームに追加</button>
+  <button id="addToHome" class="primary"><span class="icon">+</span> ホームに追加</button>
 </header>
 
 <main>

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,9 @@
 :root{--bg:#f7f7fb;--card:#fff;--text:#0f172a;--muted:#667085;--border:#e6e8ef;--brand:#3b82f6;--radius:14px;--shadow:0 6px 18px rgba(20,21,26,.07)}
 *{box-sizing:border-box}
 body{margin:0;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Hiragino Kaku Gothic ProN,Noto Sans JP,Helvetica Neue,Arial,sans-serif;background:#f7f7fb;color:#0f172a}
-header.top{position:sticky;top:0;background:rgba(255,255,255,.9);backdrop-filter:saturate(150%) blur(8px);border-bottom:1px solid #e6e8ef;display:flex;align-items:center;justify-content:space-between;padding:12px 16px;z-index:10}
+header.top{position:sticky;top:0;background:rgba(255,255,255,.9);backdrop-filter:saturate(150%) blur(8px);border-bottom:1px solid #e6e8ef;display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;padding:8px 16px;z-index:10}
 header .title{font-weight:700}
+.top .icon{font-size:16px;margin-right:4px;line-height:1}
 main{padding:16px;max-width:980px;margin:0 auto;padding-bottom:80px}
 .card{background:#fff;border:1px solid #e6e8ef;border-radius:14px;padding:16px;margin-bottom:16px;box-shadow:0 6px 18px rgba(20,21,26,.07)}
 .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}


### PR DESCRIPTION
## Summary
- Insert plus icon into Add to Home button across pages
- Simplify header markup to keep title and button on one line
- Add spacing tweaks and icon styles to header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68982d0937748320a0962c057fbfbb37