### PR TITLE
Handle invalid coordinates in favorites

### DIFF
--- a/favorites.js
+++ b/favorites.js
@@ -12,8 +12,10 @@
   function makeKey(entry){
     const id = entry.id || "";
     const name = entry.name || "";
-    const lat = entry.lat!=null ? Number(entry.lat).toFixed(5) : "";
-    const lon = entry.lon!=null ? Number(entry.lon).toFixed(5) : "";
+    const latNum = entry.lat != null ? Number(entry.lat) : NaN;
+    const lonNum = entry.lon != null ? Number(entry.lon) : NaN;
+    const lat = isFinite(latNum) ? latNum.toFixed(5) : "";
+    const lon = isFinite(lonNum) ? lonNum.toFixed(5) : "";
     const kind = entry.kind || "";
     return id ? `${kind}:${id}` : `${kind}:${name}|${lat},${lon}`;
   }

--- a/favorites.test.js
+++ b/favorites.test.js
@@ -59,5 +59,19 @@ describe('Favorites manager', () => {
     Favorites.removeFavorite(item);
     expect(Favorites.isFavorite(item)).toBe(false);
   });
+
+  test('handles invalid coordinates without generating bad keys', () => {
+    const bad = { name: 'Mystery Spot', kind: 'spot', lat: 'oops', lon: Infinity };
+    expect(Favorites.isFavorite(bad)).toBe(false);
+    Favorites.addFavorite(bad);
+    const list = Favorites.getFavorites();
+    expect(list).toHaveLength(1);
+    expect(list[0].key).toBe('spot:Mystery Spot|,');
+    expect(list[0].key).not.toMatch(/NaN|Infinity/);
+    expect(Favorites.isFavorite(bad)).toBe(true);
+    Favorites.removeFavorite(bad);
+    expect(Favorites.isFavorite(bad)).toBe(false);
+    expect(Favorites.getFavorites()).toHaveLength(0);
+  });
 });
 


### PR DESCRIPTION
## Summary
- validate coordinates with `isFinite` before formatting keys
- cover invalid latitude/longitude inputs in favorites tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68983230d0708320b6818b4ca970682c