### PR TITLE
Use theme muted color for favorite metadata

### DIFF
--- a/favorites.html
+++ b/favorites.html
@@ -9,7 +9,7 @@
 <style>
   .fav-card{display:flex;justify-content:space-between;align-items:center;padding:12px;border-bottom:1px solid #e2e8f0}
   .fav-title{font-weight:700}
-  .fav-meta{color:#475569;font-size:13px;margin-top:4px}
+  .fav-meta{color:var(--muted);font-size:13px;margin-top:4px}
   .fav-actions{display:flex;gap:8px}
   .danger{background:#fee2e2;border-color:#fecaca}
 </style>


### PR DESCRIPTION
## Summary
- improve readability by using the CSS `--muted` variable for favorite card metadata color

## Testing
- `npm test`
- Manually viewed favorites page in dark mode

------
https://chatgpt.com/codex/tasks/task_e_689839a3f7188320a4c1bf7b891bcb1f